### PR TITLE
Enable private key authentication in snowflake

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
     environment:
       <<: *redash-environment
       PYTHONUNBUFFERED: 0
+    volumes:
+      - ./rsa_key.p8:/app/rsa_key.p8
   scheduler:
     <<: *redash-service
     command: dev_scheduler

--- a/redash/query_runner/snowflake.py
+++ b/redash/query_runner/snowflake.py
@@ -177,19 +177,17 @@ class Snowflake(BaseQueryRunner):
 
     def run_query(self, query, user):
         connection = self._get_connection()
-        cursor = connection.cursor()
 
         try:
-            cursor.execute("USE WAREHOUSE {}".format(self.configuration["warehouse"]))
-            cursor.execute("USE {}".format(self.configuration["database"]))
 
-            cursor.execute(query)
+            cursor_list = connection.execute_string("USE WAREHOUSE {}; USE {}; {}".format(
+                self.configuration["warehouse"], self.configuration["database"], query))
+            last_cursor = cursor_list[-1]
 
-            data = self._parse_results(cursor)
+            data = self._parse_results(last_cursor)
             error = None
             json_data = json_dumps(data)
         finally:
-            cursor.close()
             connection.close()
 
         return json_data, error

--- a/redash/query_runner/snowflake.py
+++ b/redash/query_runner/snowflake.py
@@ -1,10 +1,15 @@
 try:
     import snowflake.connector
+    import os
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.hazmat.primitives.asymmetric import dsa
+    from cryptography.hazmat.primitives import serialization
+    import logging
 
     enabled = True
 except ImportError:
     enabled = False
-
 
 from redash.query_runner import BaseQueryRunner, register
 from redash.query_runner import (
@@ -44,13 +49,20 @@ class Snowflake(BaseQueryRunner):
                 "password": {"type": "string"},
                 "warehouse": {"type": "string"},
                 "database": {"type": "string"},
+                "schema": {"type": "string"},
+                "role": {"type": "string"},
                 "region": {"type": "string", "default": "us-west"},
+                "host": {"type": "string"},
+                "use_private_key": {
+                    "type": "boolean",
+                    "title": "Use Private Key Combina (see compose file for path)",
+                    "default": True,
+                },
                 "lower_case_columns": {
                     "type": "boolean",
                     "title": "Lower Case Column Names in Results",
                     "default": False,
                 },
-                "host": {"type": "string"},
             },
             "order": [
                 "account",
@@ -58,10 +70,12 @@ class Snowflake(BaseQueryRunner):
                 "password",
                 "warehouse",
                 "database",
+                "schema",
+                "role",
                 "region",
                 "host",
             ],
-            "required": ["user", "password", "account", "database", "warehouse"],
+            "required": ["user", "account", "database", "warehouse"],
             "secret": ["password"],
             "extra_options": [
                 "host",
@@ -79,6 +93,21 @@ class Snowflake(BaseQueryRunner):
             return TYPE_FLOAT
         return t
 
+    @staticmethod
+    def _get_private_key_as_bytes():
+        with open("/app/rsa_key.p8", "rb") as key:
+            p_key = serialization.load_pem_private_key(
+                key.read(),
+                None,
+                backend=default_backend()
+            )
+
+        pkb = p_key.private_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption())
+        return pkb
+
     def _get_connection(self):
         region = self.configuration.get("region")
         account = self.configuration["account"]
@@ -95,13 +124,34 @@ class Snowflake(BaseQueryRunner):
             else:
                 host = "{}.snowflakecomputing.com".format(account)
 
-        connection = snowflake.connector.connect(
-            user=self.configuration["user"],
-            password=self.configuration["password"],
-            account=account,
-            region=region,
-            host=host,
-        )
+        # Private key mounted to volume and user selected to use private key checkbox.
+        # See docker-compose.yml server volume.
+        connection_args = {
+            "user": self.configuration["user"],
+            "account": account,
+            "region": region,
+            "host": host,
+            "warehouse": self.configuration.get("warehouse"),
+            "database": self.configuration.get("database"),
+        }
+
+        if self.configuration.get("schema"):
+            connection_args["schema"] = self.configuration.get("schema")
+        if self.configuration.get("role"):
+            connection_args["role"] = self.configuration.get("role")
+
+        if self.configuration.get("use_private_key"):
+            logging.info("Initializing connection with private key")
+            connection_args["private_key"] = self._get_private_key_as_bytes()
+
+        else:
+            logging.info("Initializing connection with username and password :(")
+            if not self.configuration["password"]:
+                raise Exception("Password is required when not using private key.")
+
+            connection_args["password"] = self.configuration["password"]
+
+        connection = snowflake.connector.connect(**connection_args)
 
         return connection
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ pytz>=2019.3
 PyYAML==5.1.2
 redis==3.5.0
 requests==2.21.0
-SQLAlchemy==1.3.10
+SQLAlchemy==1.3.24
 # We can't upgrade SQLAlchemy-Searchable version as newer versions require PostgreSQL > 9.6, but we target older versions at the moment.
 SQLAlchemy-Searchable==0.10.6
 # We need to pin the version of pyparsing, as newer versions break SQLAlchemy-Searchable-10.0.6 (newer versions no longer depend on it)


### PR DESCRIPTION
Add a volume to docker-compose that maps the private key to the container working directory.
Add backend support to use private key authentication for snowflake connector.
Add backend support to use multiple statements in a single API call (return only last cursor result).
Add a checkbox to the UI to select private key authentication for snowflake connector.
Add snowflake connector fields to the UI.
Remove password from the required fields in the UI (snowflake).
