### PR TITLE
Add charset mysql

### DIFF
--- a/redash/query_runner/mysql.py
+++ b/redash/query_runner/mysql.py
@@ -67,7 +67,7 @@ class Mysql(BaseSQLQueryRunner):
                 "db": {"type": "string", "title": "Database name"},
                 "port": {"type": "number", "default": 3306},
                 "connect_timeout": {"type": "number", "default": 60, "title": "Connection Timeout"},
-                "charset": {"type": "string", "default": "utf8"},
+                "charset": {"type": "string", "default": "utf8mb4", "title": "Character Set"},
                 "use_unicode": {"type": "boolean", "default": True},
             },
             "order": ["host", "port", "user", "passwd", "db", "connect_timeout", "charset", "use_unicode"],

--- a/redash/query_runner/mysql.py
+++ b/redash/query_runner/mysql.py
@@ -67,7 +67,7 @@ class Mysql(BaseSQLQueryRunner):
                 "db": {"type": "string", "title": "Database name"},
                 "port": {"type": "number", "default": 3306},
                 "connect_timeout": {"type": "number", "default": 60, "title": "Connection Timeout"},
-                "charset": {"type": "string", "default": "utf8mb4", "title": "Character Set"},
+                "charset": {"type": "string", "default": "utf8", "title": "Character Set"},
                 "use_unicode": {"type": "boolean", "default": True},
             },
             "order": ["host", "port", "user", "passwd", "db", "connect_timeout", "charset", "use_unicode"],


### PR DESCRIPTION
Add an option in the UI to set the charset for the MySQL connector.
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
